### PR TITLE
Fixing False Positive For Testing Proxies

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import RandomHeaders
 import re
 import urllib
 import time
+import csv
 from time import gmtime, strftime
 
 app = Flask(__name__)

--- a/app.py
+++ b/app.py
@@ -86,7 +86,7 @@ def index():
 				port = proxy.split(':')[1]
 				proxyInfo['IP'] = ip
 				proxyInfo['Port'] = port
-				proxyInfo['Ping'] = getPing('https://www.github.com/', ip=ip, port=port)
+				proxyInfo['Ping'] = getPing('http://www.adidas.com/', ip=ip, port=port)
 				proxyInfo['ConnectTime'] = returnTime()
 				info.append(proxyInfo)
 			except:

--- a/proxy_tests.py
+++ b/proxy_tests.py
@@ -1,0 +1,33 @@
+import unittest
+from app import configure_proxy_settings
+
+IP = '127.0.0.1'
+PORT = '8000'
+USERNAME = 'user'
+PASSWORD = 'password'
+
+
+class ProxyConfigTestCase(unittest.TestCase):
+    def test_proxies_without_credentials(self):
+        actual = configure_proxy_settings(IP, PORT)
+        expected = {'http': 'http://127.0.0.1:8000',
+                    'https': 'https://127.0.0.1:8000'
+                    }
+        self.assertEqual(actual, expected,
+                         'Proxy is not configured properly, showing {}'.format(actual))
+
+    def test_proxies_with_credentials(self):
+        actual = configure_proxy_settings(IP, PORT, username=USERNAME, password=PASSWORD)
+        expected = {'http': 'http://user:password@127.0.0.1:8000',
+                    'https': 'https://user:password@127.0.0.1:8000'
+                    }
+        self.assertEqual(actual, expected,
+                         'Proxy is not configured properly, showing {}'.format(actual))
+
+    def test_proxies_with_empty_parameters(self):
+        actual = configure_proxy_settings(None, None)
+        self.assertEqual(actual, None,'Proxy is not configured properly, this should return None')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When testing proxies requests, they were not configured with any proxy settings. 
- Modified `getPing(..)` to include proxy configurations
- Fixed missing import for CSV
  